### PR TITLE
カテゴリー別一覧表示機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,11 +3,12 @@ class PostsController < ApplicationController
   before_action :set_post, only: [:show, :edit, :update, :destroy]
 
   def index
-    if params[:dog_size_id]
+    if params[:theme_id]
+      @posts = Post.where(theme_id: params[:theme_id])
+    elsif params[:dog_size_id]
       @posts = Post.where(dog_size_id: params[:dog_size_id])
     elsif params[:tag_name]
       @posts = Post.tagged_with("#{params[:tag_name]}")
-      # binding.pry
     else
       @posts = Post.order(created_at: :DESC)
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,18 +38,18 @@
             <label for="theme_title">テーマから探す</label>
             <input type="checkbox" id="theme_title" class="cssacc" />
             <div class="accshow">
-              <ul class="size_lists">
-                <li>食事内容、介助方法</li>
-                <li>介護環境の対策</li>
-                <li>トイレのケア</li>
-                <li>散歩のケア</li>
-                <li>体のケア</li>
-                <li>寝たきりのケア</li>
-                <li>介護グッズ</li>
-                <li>夜泣きの対策</li>
-                <li>認知症の対策</li>
-                <li>暑さ対策</li>
-                <li>その他</li>
+              <ul class="theme_lists">
+                <li><%= link_to '食事内容、介助方法', posts_path(theme_id: 1) %></li>
+                <li><%= link_to '介護環境の対策', posts_path(theme_id: 2) %></li>
+                <li><%= link_to 'トイレのケア', posts_path(theme_id: 3) %></li>
+                <li><%= link_to '散歩のケア', posts_path(theme_id: 4) %></li>
+                <li><%= link_to '体のケア', posts_path(theme_id: 5) %></li>
+                <li><%= link_to '寝たきりのケア', posts_path(theme_id: 6) %></li>
+                <li><%= link_to '介護グッズ', posts_path(theme_id: 7) %></li>
+                <li><%= link_to '夜泣きの対策', posts_path(theme_id: 8) %></li>
+                <li><%= link_to '認知症の対策', posts_path(theme_id: 9) %></li>
+                <li><%= link_to '暑さ対策', posts_path(theme_id: 10) %></li>
+                <li><%= link_to 'その他', posts_path(theme_id: 11) %></li>
               </ul>
             </div>
           </div>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -7,22 +7,20 @@ crumb :user do |user|
   parent :root
 end
 
-crumb :post do |post|
-  link post.title, post_path(post)
-  parent :root
-end
-
 crumb :edit_user do |user|
   link "編集", edit_user_registration_path
   parent :user, user
+end
+
+crumb :post do |post|
+  link post.title, post_path(post)
+  parent :root
 end
 
 crumb :edit_post do |post|
   link "編集", edit_post_path
   parent :post, post
 end
-
-
 
 # crumb :projects do
 #   link "Projects", projects_path


### PR DESCRIPTION
## What
カテゴリー（テーマ）別で記事一覧を表示する機能の実装
## why
登録時のテーマで記事の表示を変更し、目的の情報を探しやすくするため